### PR TITLE
fix: vercel action is now triggered upon PRs in main and develop

### DIFF
--- a/.github/workflows/verceldeployment.yml
+++ b/.github/workflows/verceldeployment.yml
@@ -1,9 +1,10 @@
 name: Deploy to Vercel
 
 on:
-  push:
+  pull_request:
     branches:
       - main
+      - develop
 
 jobs:
   deploy:


### PR DESCRIPTION
This is necessary, because vercel bot (which makes a vercel deployment for each branch) only loggs in into vercel, which is only accessible for the repo owner (@KimSchlup ). But other developer want to know, why their deployment fails before pushing in main.
The deployment via Github Actions however is accessible for everyone.